### PR TITLE
Adds generator 'this' to serviceSpecsExpand call

### DIFF
--- a/generators/graphql/index.js
+++ b/generators/graphql/index.js
@@ -35,7 +35,7 @@ module.exports = class GraphqlGenerator extends Generator {
     this.log();
 
     const graphqlSpecs = specs.graphql;
-    const { mapping } = serviceSpecsExpand(specs);
+    const { mapping } = serviceSpecsExpand(specs, this);
 
     if (!Object.keys(mapping.feathers).length) {
       this.log('No services are configured as being served by GraphQL. ');


### PR DESCRIPTION

### Summary

The serviceSpecsCombine function expects a generator object, passed down from serviceSpecsExpand().  In the graphql generator, the second paramater (generator or this) was not being sent down.  This adds the generator in as the second parameter.

There are no open issues related to this.  Fix seemed easy.

This is not dependent on any other repos.

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: